### PR TITLE
Fix parallel autest runner for build-tree execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,10 +632,16 @@ if(ENABLE_DOCS)
 endif()
 
 if(ENABLE_AUTEST)
+  # Default the sandbox to /tmp to keep paths short. Unix domain socket paths
+  # are limited to 108 characters and deep build directories (e.g. in home
+  # directories) can exceed this limit, causing confusing test failures. A hash
+  # of CMAKE_BINARY_DIR provides per-build isolation while keeping the path
+  # deterministic across runs.
+  string(MD5 _build_dir_hash "${CMAKE_BINARY_DIR}")
+  string(SUBSTRING "${_build_dir_hash}" 0 8 _build_dir_hash)
   set(AUTEST_SANDBOX
-      ${CMAKE_BINARY_DIR}/_sandbox
-      CACHE STRING "Location for autest output (default
-  CMAKE_BINARY_DIR/_sandbox)"
+      "/tmp/sb_${_build_dir_hash}"
+      CACHE STRING "Location for autest output (default /tmp/sb_<hash>)"
   )
   set(AUTEST_OPTIONS
       ""

--- a/doc/developer-guide/testing/autests.en.rst
+++ b/doc/developer-guide/testing/autests.en.rst
@@ -73,6 +73,15 @@ For example, to run ``cache-auth.test.py``:
 
    ./autest.sh --sandbox /tmp/sbcursor --clean=none -f cache-auth
 
+To run tests in parallel, pass ``-j N`` where ``N`` is the number of worker
+processes. Each worker gets an isolated port range to avoid conflicts:
+
+.. code-block:: bash
+
+   ./autest.sh -j 10 --sandbox /tmp/sbcursor -f cache-auth -f cache-control
+
+Without ``-j``, tests run sequentially.
+
 Recommended Approach: ATSReplayTest
 ====================================
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 
 configure_file(pyproject.toml pyproject.toml COPYONLY)
 configure_file(autest.sh.in autest.sh)
+configure_file(autest-parallel.py.in autest-parallel.py)
 
 add_custom_target(
   autest

--- a/tests/autest-parallel.py.in
+++ b/tests/autest-parallel.py.in
@@ -31,6 +31,7 @@ import fnmatch
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -40,10 +41,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-# Default timing file location
-DEFAULT_TIMING_FILE = Path(__file__).parent / "test-timings.json"
 # Default serial tests file location
-DEFAULT_SERIAL_TESTS_FILE = Path(__file__).parent / "serial_tests.txt"
+DEFAULT_SERIAL_TESTS_FILE = Path("${CMAKE_CURRENT_SOURCE_DIR}") / "serial_tests.txt"
 # Default estimate for unknown tests (seconds)
 DEFAULT_TEST_TIME = 15.0
 
@@ -330,7 +329,8 @@ def run_single_test(test: str, script_dir: Path, sandbox: Path, ats_bin: str, bu
         status is one of: "PASS", "FAIL", "SKIP"
     """
     cmd = [
-        'uv', 'run', 'autest', 'run', '--directory', 'gold_tests', '--ats-bin', ats_bin, '--build-root', build_root, '--sandbox',
+        'uv', 'run', 'autest', 'run', '--directory', '${CMAKE_GOLD_DIR}', '--ats-bin', ats_bin, '--proxy-verifier-bin',
+        '${PROXY_VERIFIER_PATH}', '--build-root', build_root, '--sandbox',
         str(sandbox / test), '--filters', test
     ]
     cmd.extend(extra_args)
@@ -405,33 +405,45 @@ def run_worker(
     # Calculate port offset for this worker
     port_offset = worker_id * port_offset_step
 
-    # Set up environment with port offset
+    # Set up environment with port offset and PYTHONPATH for test extensions.
     env = os.environ.copy()
     env['AUTEST_PORT_OFFSET'] = str(port_offset)
+    pythonpath_dirs = [
+        '${CMAKE_CURRENT_SOURCE_DIR}/gold_tests/remap',
+        '${CMAKE_CURRENT_SOURCE_DIR}/gold_tests/lib',
+    ]
+    existing = env.get('PYTHONPATH', '')
+    env['PYTHONPATH'] = ':'.join(pythonpath_dirs + ([existing] if existing else []))
 
     if collect_timings:
         # Run tests one at a time to collect accurate timing
         all_output = []
         total_tests = len(tests)
-        for idx, test in enumerate(tests, 1):
-            test_name, duration, status, output = run_single_test(test, script_dir, sandbox, ats_bin, build_root, extra_args, env)
-            result.test_timings[test_name] = duration
-            all_output.append(output)
+        try:
+            for idx, test in enumerate(tests, 1):
+                test_name, duration, status, output = run_single_test(
+                    test, script_dir, sandbox, ats_bin, build_root, extra_args, env)
+                result.test_timings[test_name] = duration
+                all_output.append(output)
 
-            if status == "PASS":
-                result.passed += 1
-            elif status == "SKIP":
-                result.skipped += 1
-            else:
-                result.failed += 1
-                result.failed_tests.append(test_name)
+                if status == "PASS":
+                    result.passed += 1
+                elif status == "SKIP":
+                    result.skipped += 1
+                else:
+                    result.failed += 1
+                    result.failed_tests.append(test_name)
 
-            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            # Fixed-width format: date time status duration worker progress test_name
-            print(f"{timestamp} {status:4s} {duration:6.1f}s Worker:{worker_id:2d} {idx:2d}/{total_tests:2d} {test}", flush=True)
+                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                # Fixed-width format: date time status duration worker progress test_name
+                print(
+                    f"{timestamp} {status:4s} {duration:6.1f}s Worker:{worker_id:2d} {idx:2d}/{total_tests:2d} {test}", flush=True)
+        except KeyboardInterrupt:
+            result.return_code = 130
 
         result.output = "\n".join(all_output)
-        result.return_code = 0 if result.failed == 0 else 1
+        if result.return_code != 130:
+            result.return_code = 0 if result.failed == 0 else 1
     else:
         # Run all tests in batch (faster but no per-test timing)
         cmd = [
@@ -440,9 +452,11 @@ def run_worker(
             'autest',
             'run',
             '--directory',
-            'gold_tests',
+            '${CMAKE_GOLD_DIR}',
             '--ats-bin',
             ats_bin,
+            '--proxy-verifier-bin',
+            '${PROXY_VERIFIER_PATH}',
             '--build-root',
             build_root,
             '--sandbox',
@@ -478,20 +492,30 @@ def run_worker(
                     env=env,
                 )
                 output_lines = []
-                for line in proc.stdout:
-                    output_lines.append(line)
-                    # Print lines that show test progress
-                    clean = strip_ansi(line).strip()
-                    if clean.startswith('Running Test') or 'Passed' in clean or 'Failed' in clean:
-                        if clean.startswith('Running Test'):
-                            ts = datetime.now().strftime("%H:%M:%S")
-                            print(f"  [{ts}] Worker:{worker_id:2d} {clean}", flush=True)
-                # stdout is exhausted, wait for process to finish
                 try:
-                    proc.wait(timeout=60)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait()
+                    for line in proc.stdout:
+                        output_lines.append(line)
+                        # Print lines that show test progress
+                        clean = strip_ansi(line).strip()
+                        if clean.startswith('Running Test') or 'Passed' in clean or 'Failed' in clean:
+                            if clean.startswith('Running Test'):
+                                ts = datetime.now().strftime("%H:%M:%S")
+                                print(f"  [{ts}] Worker:{worker_id:2d} {clean}", flush=True)
+                    # stdout is exhausted, wait for process to finish
+                    try:
+                        proc.wait(timeout=60)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+                        proc.wait()
+                finally:
+                    # Ensure the subprocess is always cleaned up.
+                    if proc.poll() is None:
+                        proc.terminate()
+                        try:
+                            proc.wait(timeout=5)
+                        except subprocess.TimeoutExpired:
+                            proc.kill()
+                            proc.wait()
                 result.output = ''.join(output_lines)
                 result.return_code = proc.returncode
             else:
@@ -524,6 +548,10 @@ def run_worker(
                 result.failed = len(tests)
                 result.failed_tests = list(tests)
 
+        except KeyboardInterrupt:
+            result.output = "INTERRUPTED by user"
+            result.return_code = 130
+            result.failed = len(tests)
         except subprocess.TimeoutExpired:
             result.output = "TIMEOUT: Worker exceeded 1 hour timeout"
             result.return_code = -1
@@ -623,7 +651,14 @@ def print_summary(results: List[TestResult], total_duration: float, expected_tim
         f"{total_skipped:3d} skipped ({total_duration:6.1f}s)")
 
 
+def _sigterm_handler(signum, frame):
+    """Translate SIGTERM into KeyboardInterrupt so the same cleanup path runs."""
+    raise KeyboardInterrupt
+
+
 def main():
+    signal.signal(signal.SIGTERM, _sigterm_handler)
+
     parser = argparse.ArgumentParser(
         description='Run autest tests in parallel',
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -655,18 +690,20 @@ Examples:
         'Defaults to the source tree root.')
     parser.add_argument('--sandbox', default='/tmp/autest-parallel', help='Base sandbox directory (default: /tmp/autest-parallel)')
     parser.add_argument(
-        '-f', '--filter', action='append', dest='filters', help='Filter tests by glob pattern (can be specified multiple times)')
+        '-f',
+        '--filter',
+        nargs='+',
+        action='extend',
+        dest='filters',
+        help='Filter tests by name or glob pattern (multiple names can follow a single -f)')
     parser.add_argument('--list', action='store_true', help='List tests without running')
     parser.add_argument('--port-offset-step', type=int, default=1000, help='Port offset between workers (default: 1000)')
     parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
-    parser.add_argument('--test-dir', default='gold_tests', help='Test directory relative to script location (default: gold_tests)')
+    parser.add_argument('--test-dir', default='${CMAKE_GOLD_DIR}', help='Path to gold_tests directory (default: ${CMAKE_GOLD_DIR})')
     parser.add_argument(
         '--collect-timings', action='store_true', help='Run tests one at a time to collect accurate per-test timing data')
     parser.add_argument(
-        '--timings-file',
-        type=Path,
-        default=DEFAULT_TIMING_FILE,
-        help=f'Path to timing data JSON file (default: {DEFAULT_TIMING_FILE})')
+        '--timings-file', type=Path, default=None, help='Path to timing data JSON file (default: <sandbox>/test-timings.json)')
     parser.add_argument(
         '--no-timing', action='store_true', help='Disable timing-based load balancing (use round-robin partitioning)')
     parser.add_argument(
@@ -675,9 +712,12 @@ Examples:
         default=DEFAULT_SERIAL_TESTS_FILE,
         help=f'Path to file listing tests that must run serially (default: {DEFAULT_SERIAL_TESTS_FILE})')
     parser.add_argument('--no-serial', action='store_true', help='Skip serial tests entirely')
-    parser.add_argument('extra_args', nargs='*', help='Additional arguments to pass to autest')
+    args, unknown_args = parser.parse_known_args()
+    args.extra_args = unknown_args
 
-    args = parser.parse_args()
+    # Default timing file to sandbox to avoid writing into the source tree.
+    if args.timings_file is None:
+        args.timings_file = Path(args.sandbox) / "test-timings.json"
 
     # --ats-bin is required unless --list is used
     if not args.list and not args.ats_bin:
@@ -815,110 +855,137 @@ Examples:
     # Run workers in parallel
     start_time = time.time()
     results: List[TestResult] = []
+    interrupted = False
+    futures = {}
+    serial_result = None
+    serial_start = None
 
-    if partitions:
-        print_progress()
-        with ProcessPoolExecutor(max_workers=len(partitions)) as executor:
-            futures = {}
-            for worker_id, worker_tests in enumerate(partitions):
-                future = executor.submit(
-                    run_worker,
-                    worker_id=worker_id,
-                    tests=worker_tests,
-                    script_dir=script_dir,
-                    sandbox_base=sandbox_base,
-                    ats_bin=args.ats_bin,
-                    build_root=build_root,
-                    extra_args=args.extra_args or [],
-                    port_offset_step=args.port_offset_step,
-                    verbose=args.verbose,
-                    collect_timings=args.collect_timings)
-                futures[future] = worker_id
+    try:
+        if partitions:
+            print_progress()
+            with ProcessPoolExecutor(max_workers=len(partitions)) as executor:
+                for worker_id, worker_tests in enumerate(partitions):
+                    future = executor.submit(
+                        run_worker,
+                        worker_id=worker_id,
+                        tests=worker_tests,
+                        script_dir=script_dir,
+                        sandbox_base=sandbox_base,
+                        ats_bin=args.ats_bin,
+                        build_root=build_root,
+                        extra_args=args.extra_args or [],
+                        port_offset_step=args.port_offset_step,
+                        verbose=args.verbose,
+                        collect_timings=args.collect_timings)
+                    futures[future] = worker_id
 
-            # Collect results as they complete
-            for future in as_completed(futures):
-                worker_id = futures[future]
+                # Collect results as they complete
+                for future in as_completed(futures):
+                    worker_id = futures[future]
+                    try:
+                        result = future.result()
+                        results.append(result)
+                        workers_done += 1
+                        # Use actual test count (top-level), not autest sub-test counts
+                        tests_done += len(result.tests)
+                        # Count top-level tests that failed (from failed_tests list)
+                        tests_failed += len(result.failed_tests)
+                        # Skipped is still useful from autest counts for visibility
+                        tests_skipped += result.skipped
+
+                        if args.verbose:
+                            # In verbose mode, print detail line then progress
+                            status = "PASS" if result.failed == 0 else "FAIL"
+                            ts = datetime.now().strftime("%H:%M:%S")
+                            parts = [f"{result.passed} passed", f"{result.failed} failed"]
+                            if result.skipped > 0:
+                                parts.append(f"{result.skipped} skipped")
+                            # Clear the progress line, print detail, then re-print progress
+                            print(
+                                f"\r[{ts}] Worker:{worker_id:2d} Done: {', '.join(parts)} "
+                                f"({result.duration:.1f}s) [{status}]" + " " * 20)
+
+                        print_progress()
+                    except Exception as e:
+                        print(f"\r[Worker {worker_id}] Error: {e}" + " " * 20, file=sys.stderr)
+                        workers_done += 1
+                        tests_done += len(partitions[worker_id])
+                        tests_failed += len(partitions[worker_id])
+                        results.append(
+                            TestResult(
+                                worker_id=worker_id, tests=partitions[worker_id], failed=len(partitions[worker_id]), output=str(e)))
+                        print_progress()
+
+            # Clear the progress line after parallel phase
+            print()
+
+        # Run serial tests after parallel tests complete
+        if serial_tests_to_run and not args.no_serial:
+            print(f"{'=' * 70}")
+            print("RUNNING SERIAL TESTS")
+            print(f"{'=' * 70}")
+            serial_start = time.time()
+
+            # Use a special worker ID for serial tests (after parallel workers)
+            serial_worker_id = len(partitions) if partitions else 0
+
+            # Set up environment without port offset (serial tests run alone)
+            env = os.environ.copy()
+            env['AUTEST_PORT_OFFSET'] = '0'
+
+            serial_result = TestResult(worker_id=serial_worker_id, tests=serial_tests_to_run, is_serial=True)
+
+            for idx, test in enumerate(serial_tests_to_run, 1):
+                test_name, duration, status, output = run_single_test(
+                    test, script_dir, sandbox_base / "serial", args.ats_bin, build_root, args.extra_args or [], env)
+                serial_result.test_timings[test_name] = duration
+
+                if status == "PASS":
+                    serial_result.passed += 1
+                elif status == "SKIP":
+                    serial_result.skipped += 1
+                    tests_skipped += 1
+                else:
+                    serial_result.failed += 1
+                    serial_result.failed_tests.append(test_name)
+                    tests_failed += 1
+                tests_done += 1
+
+                if args.verbose:
+                    timestamp = datetime.now().strftime("%H:%M:%S")
+                    print(
+                        f"\r[{timestamp}] {status:4s} {duration:6.1f}s Serial {idx:2d}/{len(serial_tests_to_run):2d} {test}" +
+                        " " * 20)
+
+                print_progress(phase="Serial")
+
+            serial_result.duration = time.time() - serial_start
+            results.append(serial_result)
+
+            # Clear the progress line after serial phase
+            print()
+
+    except KeyboardInterrupt:
+        interrupted = True
+        print("\n\nInterrupted! Collecting completed results...")
+        # Collect any parallel worker results that completed before the
+        # interrupt. The ProcessPoolExecutor's shutdown(wait=True) in __exit__
+        # will have waited for workers (which also received SIGINT) to finish,
+        # so completed futures are available here.
+        seen_workers = {r.worker_id for r in results}
+        for future in futures:
+            if future.done() and not future.cancelled():
                 try:
-                    result = future.result()
-                    results.append(result)
-                    workers_done += 1
-                    # Use actual test count (top-level), not autest sub-test counts
-                    tests_done += len(result.tests)
-                    # Count top-level tests that failed (from failed_tests list)
-                    tests_failed += len(result.failed_tests)
-                    # Skipped is still useful from autest counts for visibility
-                    tests_skipped += result.skipped
-
-                    if args.verbose:
-                        # In verbose mode, print detail line then progress
-                        status = "PASS" if result.failed == 0 else "FAIL"
-                        ts = datetime.now().strftime("%H:%M:%S")
-                        parts = [f"{result.passed} passed", f"{result.failed} failed"]
-                        if result.skipped > 0:
-                            parts.append(f"{result.skipped} skipped")
-                        # Clear the progress line, print detail, then re-print progress
-                        print(
-                            f"\r[{ts}] Worker:{worker_id:2d} Done: {', '.join(parts)} "
-                            f"({result.duration:.1f}s) [{status}]" + " " * 20)
-
-                    print_progress()
-                except Exception as e:
-                    print(f"\r[Worker {worker_id}] Error: {e}" + " " * 20, file=sys.stderr)
-                    workers_done += 1
-                    tests_done += len(partitions[worker_id])
-                    tests_failed += len(partitions[worker_id])
-                    results.append(
-                        TestResult(
-                            worker_id=worker_id, tests=partitions[worker_id], failed=len(partitions[worker_id]), output=str(e)))
-                    print_progress()
-
-        # Clear the progress line after parallel phase
-        print()
-
-    # Run serial tests after parallel tests complete
-    if serial_tests_to_run and not args.no_serial:
-        print(f"{'=' * 70}")
-        print("RUNNING SERIAL TESTS")
-        print(f"{'=' * 70}")
-        serial_start = time.time()
-
-        # Use a special worker ID for serial tests (after parallel workers)
-        serial_worker_id = len(partitions) if partitions else 0
-
-        # Set up environment without port offset (serial tests run alone)
-        env = os.environ.copy()
-        env['AUTEST_PORT_OFFSET'] = '0'
-
-        serial_result = TestResult(worker_id=serial_worker_id, tests=serial_tests_to_run, is_serial=True)
-
-        for idx, test in enumerate(serial_tests_to_run, 1):
-            test_name, duration, status, output = run_single_test(
-                test, script_dir, sandbox_base / "serial", args.ats_bin, build_root, args.extra_args or [], env)
-            serial_result.test_timings[test_name] = duration
-
-            if status == "PASS":
-                serial_result.passed += 1
-            elif status == "SKIP":
-                serial_result.skipped += 1
-                tests_skipped += 1
-            else:
-                serial_result.failed += 1
-                serial_result.failed_tests.append(test_name)
-                tests_failed += 1
-            tests_done += 1
-
-            if args.verbose:
-                timestamp = datetime.now().strftime("%H:%M:%S")
-                print(
-                    f"\r[{timestamp}] {status:4s} {duration:6.1f}s Serial {idx:2d}/{len(serial_tests_to_run):2d} {test}" + " " * 20)
-
-            print_progress(phase="Serial")
-
-        serial_result.duration = time.time() - serial_start
-        results.append(serial_result)
-
-        # Clear the progress line after serial phase
-        print()
+                    r = future.result(timeout=0)
+                    if r.worker_id not in seen_workers:
+                        results.append(r)
+                        seen_workers.add(r.worker_id)
+                except Exception:
+                    pass
+        # Capture partial serial results if we were in the serial phase.
+        if serial_result is not None and serial_result.worker_id not in seen_workers:
+            serial_result.duration = time.time() - serial_start
+            results.append(serial_result)
 
     total_duration = time.time() - start_time
 
@@ -942,6 +1009,9 @@ Examples:
     print_summary(results, total_duration, timings if args.collect_timings else None)
 
     # Exit with non-zero if any tests failed
+    if interrupted:
+        print("\nRun was interrupted by user.")
+        sys.exit(130)
     total_failed = sum(r.failed + r.exceptions for r in results)
     sys.exit(1 if total_failed > 0 else 0)
 

--- a/tests/autest.sh.in
+++ b/tests/autest.sh.in
@@ -1,13 +1,18 @@
 #!/bin/bash
 #
-# conveinience script for running autest after building the target
+# convenience script for running autest after building the target
 #
+# Usage:
+#   ./autest.sh [autest args]           # run tests sequentially
+#   ./autest.sh -j N [autest args]      # run tests in parallel with N workers
 #
 
 export LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib
 export PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/gold_tests/remap:${CMAKE_CURRENT_SOURCE_DIR}/gold_tests/lib:$PYTHONPATH
 
-# Define tests to skip for CURL_UDS_FLAG
+# Move test directories that require features not supported by the current curl
+# build. This must happen before the parallel runner dispatches because it
+# discovers tests by scanning the gold_tests directory.
 if [ -n "${CURL_UDS_FLAG}" ]; then
   mkdir -p "${CMAKE_SKIP_GOLD_DIR}"
   if [ -d "${CMAKE_GOLD_DIR}/h2" ]; then
@@ -21,17 +26,37 @@ if [ -n "${CURL_UDS_FLAG}" ]; then
   fi
 fi
 
-uv run autest \
-  --sandbox ${AUTEST_SANDBOX} \
-  --directory ${CMAKE_GOLD_DIR} \
-  --ats-bin=${CMAKE_INSTALL_PREFIX}/bin \
-  --proxy-verifier-bin ${PROXY_VERIFIER_PATH} \
-  --build-root ${CMAKE_BINARY_DIR} \
-  ${CURL_UDS_FLAG} ${AUTEST_OPTIONS} \
-  "$@"
-autest_exit=$?
+# Check whether parallel mode was requested.
+parallel_mode=false
+for arg in "$@"; do
+  case "$arg" in
+    -j|-j[0-9]*|--jobs|--jobs=*)
+      parallel_mode=true
+      break
+      ;;
+  esac
+done
 
-# Restore tests back to source tree and remove temp dir
+if $parallel_mode; then
+  python3 "$(dirname "$0")/autest-parallel.py" \
+    --ats-bin=${CMAKE_INSTALL_PREFIX}/bin \
+    --build-root ${CMAKE_BINARY_DIR} \
+    --sandbox ${AUTEST_SANDBOX} \
+    ${CURL_UDS_FLAG} ${AUTEST_OPTIONS} "$@"
+  autest_exit=$?
+else
+  uv run autest \
+    --sandbox ${AUTEST_SANDBOX} \
+    --directory ${CMAKE_GOLD_DIR} \
+    --ats-bin=${CMAKE_INSTALL_PREFIX}/bin \
+    --proxy-verifier-bin ${PROXY_VERIFIER_PATH} \
+    --build-root ${CMAKE_BINARY_DIR} \
+    ${CURL_UDS_FLAG} ${AUTEST_OPTIONS} \
+    "$@"
+  autest_exit=$?
+fi
+
+# Restore tests back to source tree and remove temp dir.
 if [ -n "${CURL_UDS_FLAG}" ]; then
   if [ -d "${CMAKE_SKIP_GOLD_DIR}/h2" ]; then
     mv "${CMAKE_SKIP_GOLD_DIR}/h2" "${CMAKE_GOLD_DIR}/h2"


### PR DESCRIPTION
The parallel runner from PR #12867 assumed it ran from the source tree,
but the project convention is to run tests from the build directory
where uv, pyproject.toml, and compiled test plugins reside. This commit
converts autest-parallel.py to a CMake .in template so configure_file
substitutes the correct absolute paths for gold_tests, proxy-verifier,
serial_tests.txt, and PYTHONPATH. It also adds --proxy-verifier-bin and
PYTHONPATH setup that the original script was missing (both are required
by the autest test harness), and integrates the runner into autest.sh so
that passing -j N delegates to autest-parallel.py while the default
sequential path is unchanged.

In addition, several resource management and correctness issues
identified during code review are addressed:

The standalone tests/autest-parallel.py was a stale copy of the CMake
template. Since CMake already generates it in the build tree from the
.py.in template, the source-tree copy is removed.

In autest.sh.in, the CURL_UDS_FLAG block (which excludes h2, tls, and
tls_hooks tests when curl lacks Unix Domain Socket support) ran after the
parallel dispatch and used "exec", so it never executed for parallel
runs. The block is moved before the dispatch, "exec" is replaced with a
regular invocation so the cleanup code always runs, and CURL_UDS_FLAG and
AUTEST_OPTIONS are forwarded to the parallel runner.

In the parallel runner itself: the verbose-mode Popen path now has a
try/finally to prevent child process leaks on exceptions; both the
collect_timings and batch code paths catch KeyboardInterrupt and return
clean results with exit code 130; the main function wraps the entire
execution phase in try/except KeyboardInterrupt to collect partial
results and exit cleanly on Ctrl+C; SIGTERM is translated to
KeyboardInterrupt via a signal handler for consistent cleanup.

The default test-timings.json location is moved from the source tree to
the sandbox directory to avoid polluting the repository.

The -f/--filter argument is changed from action='append' to nargs='+'
with action='extend' so that "-f test1 test2 test3" works, matching
sequential autest behavior and CI pipeline usage.